### PR TITLE
Update TabNavigation.tsx

### DIFF
--- a/src/components/TabNavigation/TabNavigation.tsx
+++ b/src/components/TabNavigation/TabNavigation.tsx
@@ -1,4 +1,4 @@
-// Tremor Raw TabNavigation [v0.0.0]
+// Tremor Raw TabNavigation [v0.0.1]
 
 import React from "react"
 import * as NavigationMenuPrimitives from "@radix-ui/react-navigation-menu"
@@ -44,6 +44,7 @@ const TabNavigation = React.forwardRef<
     </NavigationMenuPrimitives.List>
   </NavigationMenuPrimitives.Root>
 ))
+
 TabNavigation.displayName = "TabNavigation"
 
 const TabNavigationLink = React.forwardRef<
@@ -93,6 +94,7 @@ const TabNavigationLink = React.forwardRef<
     </NavigationMenuPrimitives.Link>
   </NavigationMenuPrimitives.Item>
 ))
+
 TabNavigationLink.displayName = "TabNavigationLink"
 
 export { TabNavigation, TabNavigationLink }

--- a/src/components/TabNavigation/changelog.md
+++ b/src/components/TabNavigation/changelog.md
@@ -1,5 +1,7 @@
 # Tremor Raw TabNavigation Changelog
 
-## 0.0.0
+## 0.0.1
 
 ### Changes
+
+- Fix: Link dislay name


### PR DESCRIPTION
errors out, now it don't

**Description**
The TabNavigationLink component errors: Component definition is missing display nameeslint[react/display-name], i thought that it should be the link instead because the tab navigation has already been given a display name a couple of lines above.


**What kind of change does this PR introduce?** (check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
![image](https://github.com/tremorlabs/tremor-raw/assets/103997539/7da4cd6e-4119-4247-9151-373f550efbad)
![image](https://github.com/tremorlabs/tremor-raw/assets/103997539/7707b229-2e16-421f-8279-d279db215362)
![image](https://github.com/tremorlabs/tremor-raw/assets/103997539/656b4fda-05ad-4919-bc2c-cb5115e8dfdf)


**The PR fulfils these requirements:**

- [x] It's submitted to the `main` branch
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor-raw/blob/main/License) license.
