### PR TITLE
feat: Add `Slottable` from Radix UI for better component composition

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -122,7 +122,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cx(buttonVariants({ variant }), className)}
         disabled={disabled || isLoading}
         tremor-id="tremor-raw"
-        data-loading={isLoading}
         {...props}
       >
         {isLoading && (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 // Tremor Button [v1.0.0]
 
 import React from "react"
-import { Slot } from "@radix-ui/react-slot"
+import { Slot, Slottable } from "@radix-ui/react-slot"
 import { RiLoader2Fill } from "@remixicon/react"
 import { tv, type VariantProps } from "tailwind-variants"
 
@@ -95,7 +95,7 @@ const buttonVariants = tv({
 
 interface ButtonProps
   extends React.ComponentPropsWithoutRef<"button">,
-    VariantProps<typeof buttonVariants> {
+  VariantProps<typeof buttonVariants> {
   asChild?: boolean
   isLoading?: boolean
   loadingText?: string
@@ -122,10 +122,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cx(buttonVariants({ variant }), className)}
         disabled={disabled || isLoading}
         tremor-id="tremor-raw"
+        data-loading={isLoading}
         {...props}
       >
-        {isLoading ? (
-          <span className="pointer-events-none flex shrink-0 items-center justify-center gap-1.5">
+        {isLoading && (
+          <>
             <RiLoader2Fill
               className="size-4 shrink-0 animate-spin"
               aria-hidden="true"
@@ -133,11 +134,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <span className="sr-only">
               {loadingText ? loadingText : "Loading"}
             </span>
-            {loadingText ? loadingText : children}
-          </span>
-        ) : (
-          children
+          </>
         )}
+        <Slottable>{isLoading && loadingText ? loadingText : children}</Slottable>
       </Component>
     )
   },


### PR DESCRIPTION
**Description**

This PR introduces the usage of `Slottable` from `@radix-ui/react-slot` in the Button component. The main change is replacing the direct rendering of children with `Slottable`, which provides better component composition and flexibility.

Key changes:
- Added `Slottable` from Radix UI
- Restructured loading state rendering using `Slottable`
- Simplified the loading state logic

**Related issue(s)**
None

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**How has this been tested?**

The changes have been tested in the following scenarios:
- Button component with Slottable integration
- Button component with loading states
- Button component with children composition

**The PR fulfils these requirements:**

- [x] It's submitted to the `main` branch
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor-npm/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor?tab=Apache-2.0-1-ov-file#readme) license.